### PR TITLE
Add "default" host

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ These dictionaries support the following options:
 | --- | --- | --- | --- | --- |
 | `create` | `true`, `false` | `false` | No | Specifies if the parent directory should be created if necessary. |
 | `force` | `true`, `false` | `false` | No | Specifies if the file or directory should be forcibly linked. **This can cause irreversible data loss! Use with caution!** |
-| `hosts` | `dict` | `{}` | No |  Contains key-value entries with hostnames and their associated target path this link should be processed for. Links with an empty dictionary will be processed irrespective of the host. |
+| `hosts` | `dict` | `{}` | No |  Contains key-value entries with hostnames and their associated target path this link should be processed for. Links with an empty dictionary will be processed irrespective of the host.<br><br>The `default` hostname can be specified as fallback target if non of the given hostnames matched. **Note that this will not work for target hosts named `default`!** |
 | `path` | `string`, `null` | `null` | No |  The path to map the source path. If the path is omitted or `null`, snowsaw will use the basename of the destination, with a leading `.` stripped if present. |
 | `relink` | `true`, `false` | `false` |  No | Specifies if incorrect symbolic links should be automatically overwritten. |
 | `relative` | `true`, `false` | `false` |  No | Specifies if the symbolic link should have a relative path. |
@@ -204,7 +204,8 @@ These dictionaries support the following options:
         "create": true,
         "hosts": {
           "archlinux-home": "gitconfig.home",
-          "archlinux-work": "gitconfig.work"
+          "archlinux-work": "gitconfig.work",
+          "default": "gitconfig.base"
         }
       },
       "~/.gitconfig_auth": {

--- a/snowsaw/plugins/link.py
+++ b/snowsaw/plugins/link.py
@@ -47,18 +47,20 @@ class Link(snowsaw.Plugin):
             path = os.path.expandvars(os.path.expanduser(path))
 
             if hosts:
-                for host in hosts.items():
-                    if not host[0] == hostname:
+                if hostname in hosts:
+                    path = os.path.expandvars(os.path.expanduser(hosts.get(hostname)))
+                elif "default" in hosts:
+                    path = os.path.expandvars(os.path.expanduser(hosts.get("default")))
+                    self._log.lowinfo("Applying default link {} -> {}".format(destination, os.path.join(self._context.snowblock_dir(),path)))
+                else:
+                    for host in hosts.items():
                         self._log.lowinfo("Skipped host specific link {} -> {}".format(destination, os.path.join(self._context.snowblock_dir(), host[1])))
-                        continue
-                    else:
-                        path = os.path.expandvars(os.path.expanduser(hosts.get(hostname)))
+                    return True
 
             if not self._exists(os.path.join(self._context.snowblock_dir(), path)):
                 success = False
                 self._log.warning("Nonexistent target {} -> {}".format(destination, path))
                 continue
-
             if create:
                 success &= self._create(destination)
             if force or relink:


### PR DESCRIPTION
> Closes #21

Machines that do not have a specific entry.

- Rewrote for loop that processes hosts to immediately exit if the host
  name is matched

- Modified host matching so that if the hostname is not matched, and a
  default is not set, it will immediately return to the caller

These changes allow for the following scenarios:
1) Apply the link to all hosts (no hosts specified)
2) Apply link to ONLY specific hosts (hosts specified with no default)
3) Apply host-specific links, or a default for non-matched hostnames
(hosts and default specified)