### PR TITLE
Add per-host capability to shell plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Shell tasks support an extended syntax as well, which provides more fine-grained
 
 | Option | Values | Default Value | Required | Description |
 | --- | --- | --- | --- | --- |
+| `host` | `string` | - | No | The hostname of the machine this script should be executed on. Not supplying a host will result in the shell command executing on every host.<br><br>The hostname '-' can be specified as a default target that will match all hosts. |
 | `command` | `string` | - |  Yes | The command to be run. |
 | `description` | `string` | - | No |  A human-readable description. |
 | `stdin` | `true`, `false` | `false` | No |  Specifies if the standard input stream is enabled. |


### PR DESCRIPTION
Currently, any configured script will execute on all hosts. This commit
will allow for a host item in the config so that the script will only
run on the specific host. A hostname of "-" will match all hosts. For
backwards compatibility, a config with no host specified will run
on all hosts.