### PR TITLE
Fix a bug when the current host is not in listed hosts of a link item

### DIFF
--- a/snowsaw/plugins/link.py
+++ b/snowsaw/plugins/link.py
@@ -57,7 +57,7 @@ class Link(snowsaw.Plugin):
                 else:
                     for host in hosts.items():
                         self._log.lowinfo("Skipped host specific link {} -> {}".format(destination, os.path.join(self._context.snowblock_dir(), host[1])))
-                    return True
+                    continue
 
             if not self._exists(os.path.join(self._context.snowblock_dir(), path)):
                 success = False


### PR DESCRIPTION
When one link item in a link task has a target host that doesn't match the current host name, the current link item will be skipped. This is intended. However, all other link items following the current link item will also be skipped. This behavior is a bug. This PR fixes this bug.