### PR TITLE
The way to go: more helpful error message when destination files already exist

### DIFF
--- a/pkg/snowblock/task/link/link.go
+++ b/pkg/snowblock/task/link/link.go
@@ -234,7 +234,7 @@ func (l *Link) execute() error {
 			return nil
 		}
 
-		return fmt.Errorf("file or directory already exists: %s", l.config.Path)
+		return fmt.Errorf("file or directory already exists: %s", l.destAbsPath)
 	}
 
 	// ...otherwise only when all previous conditions are not met.


### PR DESCRIPTION
When a destination file of a `link` task already exists, the program should dump the path of the destination file, not the path of the file in the `snowblock` directory. This way the user can go to check the existing destination file immediately.